### PR TITLE
try out Swatinem/rust-cache@v2

### DIFF
--- a/.github/workflows/local-testnet.yml
+++ b/.github/workflows/local-testnet.yml
@@ -35,16 +35,19 @@ jobs:
         if: matrix.os == 'macos-12'
 
       # https://github.com/actions/cache/blob/main/examples.md#rust---cargo
-      - uses: actions/cache@v3
-        id: cache-cargo
-        with:
-          path: |
-              ~/.cargo/bin/
-              ~/.cargo/registry/index/
-              ~/.cargo/registry/cache/
-              ~/.cargo/git/db/
-              target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      # - uses: actions/cache@v3
+      #   id: cache-cargo
+      #   with:
+      #     path: |
+      #         ~/.cargo/bin/
+      #         ~/.cargo/registry/index/
+      #         ~/.cargo/registry/cache/
+      #         ~/.cargo/git/db/
+      #         target/
+      #     key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: rust-cache
+        uses: Swatinem/rust-cache@v2
 
       - name: Install lighthouse
         run: make && make install-lcli

--- a/.github/workflows/local-testnet.yml
+++ b/.github/workflows/local-testnet.yml
@@ -48,6 +48,8 @@ jobs:
 
       - name: rust-cache
         uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
 
       - name: Install lighthouse
         run: make && make install-lcli


### PR DESCRIPTION
[`Swatinem/rust-cache@v2`](https://github.com/Swatinem/rust-cache) is a GitHub action that implements caching for Rust/Cargo projects. It may be worth comparing it against the existing caching mechanism using [examples](https://github.com/actions/cache/blob/main/examples.md#rust---cargo) provided by GitHub.

One of the useful feature is to allow storing cache when the job fails, which could be useful for Lighthouse's `local_testnet` testing, which takes a long time to build from scratch.