### PR TITLE
Gradual publication of data columns for supernodes

### DIFF
--- a/beacon_node/beacon_chain/src/fetch_blobs.rs
+++ b/beacon_node/beacon_chain/src/fetch_blobs.rs
@@ -184,6 +184,7 @@ pub async fn fetch_and_process_engine_blobs<T: BeaconChainTypes>(
                     // other supernodes in the meantime, obviating the need for us to publish
                     // them. If no other publisher exists for a column, it will eventually get
                     // published here.
+                    // FIXME(das): deduplicate this wrt to gossip/sync methods
                     all_data_columns.shuffle(&mut rand::thread_rng());
 
                     let batch_size =
@@ -206,6 +207,7 @@ pub async fn fetch_and_process_engine_blobs<T: BeaconChainTypes>(
                             );
                             publish_fn(BlobsOrDataColumns::DataColumns(publishable));
                         }
+                        tokio::time::sleep(SUPERNODE_DATA_COLUMN_PUBLICATION_BATCH_INTERVAL).await;
                     }
                 },
                 "compute_data_columns",

--- a/beacon_node/beacon_chain/src/fetch_blobs.rs
+++ b/beacon_node/beacon_chain/src/fetch_blobs.rs
@@ -7,25 +7,30 @@
 //! on P2P gossip to the network. From PeerDAS onwards, together with the increase in blob count,
 //! broadcasting blobs requires a much higher bandwidth, and is only done by high capacity
 //! supernodes.
-use std::sync::Arc;
-
+use crate::kzg_utils::blobs_to_data_column_sidecars;
+use crate::observed_data_sidecars::ObservableDataSidecar;
+use crate::{metrics, BeaconChain, BeaconChainTypes, BlockError};
 use execution_layer::json_structures::BlobAndProofV1;
 use execution_layer::Error as ExecutionLayerError;
 use itertools::Either;
+use lighthouse_metrics::{inc_counter, TryExt};
+use rand::prelude::SliceRandom;
 use slog::{debug, error, warn};
 use ssz_types::FixedVector;
-
-use lighthouse_metrics::{inc_counter, TryExt};
 use state_processing::per_block_processing::deneb::kzg_commitment_to_versioned_hash;
+use std::sync::Arc;
+use std::time::Duration;
 use types::blob_sidecar::{BlobSidecarError, FixedBlobSidecarList};
 use types::{
     BeaconStateError, BlobSidecar, DataColumnSidecarList, EthSpec, FullPayload, Hash256,
     SignedBeaconBlock, SignedBeaconBlockHeader,
 };
 
-use crate::kzg_utils::blobs_to_data_column_sidecars;
-use crate::observed_data_sidecars::ObservableDataSidecar;
-use crate::{metrics, BeaconChain, BeaconChainTypes, BlockError};
+/// Number of batches that supernodes split data columns into during publishing.
+pub const SUPERNODE_DATA_COLUMN_PUBLICATION_BATCHES: usize = 4;
+
+/// The delay applied by supernodes between the sending of each data column batch.
+pub const SUPERNODE_DATA_COLUMN_PUBLICATION_BATCH_INTERVAL: Duration = Duration::from_millis(200);
 
 pub enum BlobsOrDataColumns<E: EthSpec> {
     Blobs(Vec<Arc<BlobSidecar<E>>>),
@@ -49,7 +54,7 @@ pub async fn fetch_and_process_engine_blobs<T: BeaconChainTypes>(
     chain: Arc<BeaconChain<T>>,
     block_root: Hash256,
     block: Arc<SignedBeaconBlock<T::EthSpec, FullPayload<T::EthSpec>>>,
-    publish_fn: impl FnOnce(BlobsOrDataColumns<T::EthSpec>) + Send + 'static,
+    publish_fn: impl Fn(BlobsOrDataColumns<T::EthSpec>) + Send + 'static,
 ) -> Result<(), FetchEngineBlobError> {
     let versioned_hashes =
         if let Ok(kzg_commitments) = block.message().body().blob_kzg_commitments() {
@@ -144,7 +149,7 @@ pub async fn fetch_and_process_engine_blobs<T: BeaconChainTypes>(
                             .discard_timer_on_break(&mut timer);
                     drop(timer);
 
-                    let all_data_columns = match data_columns_result {
+                    let mut all_data_columns = match data_columns_result {
                         Ok(d) => d,
                         Err(e) => {
                             error!(
@@ -156,31 +161,51 @@ pub async fn fetch_and_process_engine_blobs<T: BeaconChainTypes>(
                         }
                     };
 
-                    // Check indices from cache before sending the columns, to make sure we don't
-                    // publish components already seen on gossip.
-                    let all_data_columns_iter = all_data_columns.clone().into_iter();
-                    let data_columns_to_publish = match chain_cloned
-                        .data_availability_checker
-                        .imported_custody_column_indexes(&block_root)
-                    {
-                        None => Either::Left(all_data_columns_iter),
-                        Some(imported_columns_indices) => Either::Right(
-                            all_data_columns_iter
-                                .filter(move |d| !imported_columns_indices.contains(&d.index())),
-                        ),
-                    }
-                    .collect::<Vec<_>>();
-
-                    if let Err(e) = data_columns_sender.try_send(all_data_columns) {
+                    if let Err(e) = data_columns_sender.try_send(all_data_columns.clone()) {
                         error!(logger, "Failed to send computed data columns"; "error" => ?e);
                     };
 
+                    // Check indices from cache before sending the columns, to make sure we don't
+                    // publish components already seen on gossip.
                     let is_supernode = chain_cloned
                         .data_availability_checker
                         .get_custody_columns_count()
                         == spec.number_of_columns;
-                    if is_supernode && !data_columns_to_publish.is_empty() {
-                        publish_fn(BlobsOrDataColumns::DataColumns(data_columns_to_publish));
+
+                    // At the moment non supernodes are not required to publish any columns.
+                    // TODO(das): we could experiment with having full nodes publish their custodied
+                    // columns here.
+                    if !is_supernode {
+                        return;
+                    }
+
+                    // To reduce bandwidth for supernodes: permute the columns to publish and
+                    // publish them in batches. Our hope is that some columns arrive from
+                    // other supernodes in the meantime, obviating the need for us to publish
+                    // them. If no other publisher exists for a column, it will eventually get
+                    // published here.
+                    all_data_columns.shuffle(&mut rand::thread_rng());
+
+                    let batch_size =
+                        all_data_columns.len() / SUPERNODE_DATA_COLUMN_PUBLICATION_BATCHES;
+                    for batch in all_data_columns.chunks(batch_size) {
+                        let already_seen = chain_cloned
+                            .data_availability_checker
+                            .imported_custody_column_indexes(&block_root)
+                            .unwrap_or_default();
+                        let publishable = batch
+                            .iter()
+                            .filter(|col| !already_seen.contains(&col.index()))
+                            .cloned()
+                            .collect::<Vec<_>>();
+                        if !publishable.is_empty() {
+                            debug!(
+                                chain_cloned.log,
+                                "Publishing data columns from EL";
+                                "count" => publishable.len()
+                            );
+                            publish_fn(BlobsOrDataColumns::DataColumns(publishable));
+                        }
                     }
                 },
                 "compute_data_columns",

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -190,12 +190,6 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         let self_clone = self.clone();
         self.executor.spawn(
             async move {
-                let is_supernode = self_clone
-                    .chain
-                    .data_availability_checker
-                    .get_custody_columns_count()
-                    == self_clone.chain.spec.number_of_columns;
-
                 let publish_fn = |columns: DataColumnSidecarList<T::EthSpec>| {
                     self_clone.send_network_message(NetworkMessage::Publish {
                         messages: columns
@@ -210,11 +204,6 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                             .collect(),
                     });
                 };
-
-                if !is_supernode {
-                    publish_fn(data_columns_to_publish);
-                    return;
-                }
 
                 // If this node is a super node, permute the columns and split them into batches.
                 // The hope is that we won't need to publish some columns because we will receive them

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -26,6 +26,7 @@ use lighthouse_network::{
     Client, MessageAcceptance, MessageId, PeerAction, PeerId, PubsubMessage, ReportSource,
 };
 use operation_pool::ReceivedPreCapella;
+use rand::prelude::SliceRandom;
 use slog::{crit, debug, error, info, trace, warn, Logger};
 use slot_clock::SlotClock;
 use ssz::Encode;
@@ -38,8 +39,8 @@ use store::hot_cold_store::HotColdDBError;
 use tokio::sync::mpsc;
 use types::{
     beacon_block::BlockImportSource, Attestation, AttestationRef, AttesterSlashing, BlobSidecar,
-    DataColumnSidecar, DataColumnSubnetId, EthSpec, Hash256, IndexedAttestation,
-    LightClientFinalityUpdate, LightClientOptimisticUpdate, ProposerSlashing,
+    DataColumnSidecar, DataColumnSidecarList, DataColumnSubnetId, EthSpec, Hash256,
+    IndexedAttestation, LightClientFinalityUpdate, LightClientOptimisticUpdate, ProposerSlashing,
     SignedAggregateAndProof, SignedBeaconBlock, SignedBlsToExecutionChange,
     SignedContributionAndProof, SignedVoluntaryExit, Slot, SubnetId, SyncCommitteeMessage,
     SyncSubnetId,
@@ -56,6 +57,12 @@ use beacon_processor::{
 /// Set to `true` to introduce stricter penalties for peers who send some types of late consensus
 /// messages.
 const STRICT_LATE_MESSAGE_PENALTIES: bool = false;
+
+/// Number of batches that supernodes split data columns into during publishing.
+pub const SUPERNODE_DATA_COLUMN_PUBLICATION_BATCHES: usize = 4;
+
+/// The delay applied by supernodes between the sending of each data column batch.
+pub const SUPERNODE_DATA_COLUMN_PUBLICATION_BATCH_INTERVAL: Duration = Duration::from_millis(200);
 
 /// An attestation that has been validated by the `BeaconChain`.
 ///
@@ -172,23 +179,75 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
     }
 
     pub(crate) fn handle_data_columns_to_publish(
-        &self,
+        self: &Arc<Self>,
         data_columns_to_publish: DataColumnsToPublish<T::EthSpec>,
+        block_root: Hash256,
     ) {
-        if let Some(data_columns_to_publish) = data_columns_to_publish {
-            self.send_network_message(NetworkMessage::Publish {
-                messages: data_columns_to_publish
-                    .iter()
-                    .map(|d| {
-                        let subnet = DataColumnSubnetId::from_column_index::<T::EthSpec>(
-                            d.index as usize,
-                            &self.chain.spec,
+        let Some(mut data_columns_to_publish) = data_columns_to_publish else {
+            return;
+        };
+        // let self_executor= self.clone();
+        let self_clone = self.clone();
+        self.executor.spawn(
+            async move {
+                let is_supernode = self_clone
+                    .chain
+                    .data_availability_checker
+                    .get_custody_columns_count()
+                    == self_clone.chain.spec.number_of_columns;
+
+                let publish_fn = |columns: DataColumnSidecarList<T::EthSpec>| {
+                    self_clone.send_network_message(NetworkMessage::Publish {
+                        messages: columns
+                            .into_iter()
+                            .map(|d| {
+                                let subnet = DataColumnSubnetId::from_column_index::<T::EthSpec>(
+                                    d.index as usize,
+                                    &self_clone.chain.spec,
+                                );
+                                PubsubMessage::DataColumnSidecar(Box::new((subnet, d)))
+                            })
+                            .collect(),
+                    });
+                };
+
+                if !is_supernode {
+                    publish_fn(data_columns_to_publish);
+                    return;
+                }
+
+                // If this node is a super node, permute the columns and split them into batches.
+                // The hope is that we won't need to publish some columns because we will receive them
+                // on gossip from other supernodes.
+                data_columns_to_publish.shuffle(&mut rand::thread_rng());
+                let batch_size =
+                    data_columns_to_publish.len() / SUPERNODE_DATA_COLUMN_PUBLICATION_BATCHES;
+
+                for batch in data_columns_to_publish.chunks(batch_size) {
+                    let already_seen = self_clone
+                        .chain
+                        .data_availability_checker
+                        .imported_custody_column_indexes(&block_root)
+                        .unwrap_or_default();
+                    let publishable = batch
+                        .iter()
+                        .filter(|col| !already_seen.contains(&col.index))
+                        .cloned()
+                        .collect::<Vec<_>>();
+
+                    if !publishable.is_empty() {
+                        debug!(
+                            self_clone.chain.logger(),
+                            "Publishing data column batch";
+                            "count" => publishable.len()
                         );
-                        PubsubMessage::DataColumnSidecar(Box::new((subnet, d.clone())))
-                    })
-                    .collect(),
-            });
-        }
+                        publish_fn(publishable);
+                    }
+                    tokio::time::sleep(SUPERNODE_DATA_COLUMN_PUBLICATION_BATCH_INTERVAL).await;
+                }
+            },
+            "handle_data_columns_publish",
+        );
     }
 
     /// Send a message on `message_tx` that the `message_id` sent by `peer_id` should be propagated on
@@ -1020,7 +1079,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             .await
         {
             Ok((availability, data_columns_to_publish)) => {
-                self.handle_data_columns_to_publish(data_columns_to_publish);
+                self.handle_data_columns_to_publish(data_columns_to_publish, block_root);
 
                 match availability {
                     AvailabilityProcessingStatus::Imported(block_root) => {

--- a/beacon_node/network/src/network_beacon_processor/sync_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/sync_methods.rs
@@ -345,7 +345,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
 
         match &result {
             Ok((availability, data_columns_to_publish)) => {
-                self.handle_data_columns_to_publish(data_columns_to_publish.clone());
+                self.handle_data_columns_to_publish(data_columns_to_publish.clone(), block_root);
 
                 match availability {
                     AvailabilityProcessingStatus::Imported(hash) => {


### PR DESCRIPTION
## Proposed Changes

Optimisation to push data columns out in batches on supernodes.

## Additional Info

Needs a bit of cleanup to de-duplicate logic from `fetch_blobs.rs` and `gossip_methdods.rs`
