### PR TITLE
Improve AI assistant documentation guidance

### DIFF
--- a/.ai/CHANGE_SAFETY.md
+++ b/.ai/CHANGE_SAFETY.md
@@ -1,0 +1,116 @@
+# Change Safety Guide
+
+Read this before changing behavior, shared code paths, fork logic, storage,
+networking, sync, consensus, validator duties, or any interface with multiple
+call sites.
+
+The goal is to prevent regressions. Do not only prove the new behavior works;
+prove important existing behavior still holds.
+
+## Before Editing
+
+Write down the behavioral contract in concrete terms:
+
+- What currently happens?
+- What should change?
+- What must remain unchanged?
+- Which forks, networks, store backends, sync states, or validator states are
+  affected?
+- Which public API, internal interface, metric, log, or persisted data shape can
+  callers depend on?
+
+If the answer is uncertain, inspect callers and nearby tests before editing.
+
+## Trace the Real Path
+
+Before changing a function or type, find the real consumers:
+
+```bash
+rg "function_or_type_name"
+```
+
+For each important caller, check whether it depends on:
+
+- Error variants or fallback behavior
+- `None` vs empty collection vs missing store row
+- Fork-specific behavior
+- Timing, async scheduling, or event ordering
+- Persistence across restart
+- API response shape or status code
+- Metrics, logs, or peer scoring side effects
+
+Do not rely only on the file being edited. Lighthouse regressions often happen
+because a helper is shared by import, sync, API, and validator paths with subtly
+different expectations.
+
+## Preserve Existing Behavior Deliberately
+
+For every non-trivial change, identify at least one unchanged behavior that
+could regress and make sure it is covered by a test or existing validation.
+
+Examples:
+
+- A new rejection path should not reject valid blocks from an earlier fork.
+- A new fallback should not hide a store or execution-layer error.
+- A new cache or shortcut should not change canonical head, finalization, or
+  fork choice results.
+- A new API field should not change existing response fields or status codes.
+- A refactor should keep the same error semantics unless the task explicitly
+  changes them.
+
+If no test is practical, explain the residual risk in the final response.
+
+## Fork and Consensus Changes
+
+Consensus and fork-specific changes need extra care:
+
+- Check whether the change belongs in `consensus/`, `beacon_chain`, HTTP API, or
+  validator logic. Do not move protocol rules into convenience layers.
+- Test the fork where behavior changes.
+- Test or inspect an unaffected fork when production behavior should remain the
+  same.
+- Preserve SSZ field ordering, defaults, and serde behavior when touching types.
+- Use safe arithmetic in `consensus/` excluding `types/`.
+- Avoid runtime panics and unchecked indexing.
+
+When in doubt, compare the implementation against the consensus specs in
+`./consensus-specs/`.
+
+## Async, Network, and Store Changes
+
+- Prefer event-based tests over sleeps.
+- Keep lock scopes narrow and document multi-lock ordering.
+- Do not block the async runtime with CPU-heavy work.
+- Treat store miss, corrupt data, and backend errors differently when callers do.
+- Preserve peer scoring, request limits, and retry/fallback semantics unless the
+  task explicitly changes them.
+
+## Regression Test Shape
+
+Good regression tests:
+
+- Fail if the old bug reappears.
+- Assert externally visible behavior or domain invariants.
+- Cover negative and boundary cases when meaningful.
+- Use existing harnesses and fixtures instead of custom miniature worlds.
+
+Weak regression tests:
+
+- Only assert that a mock was called.
+- Only construct the new type.
+- Assert private helper behavior without checking the caller-visible outcome.
+- Duplicate the implementation logic in the assertion.
+
+Read `.ai/TESTING.md` before adding or modifying tests.
+
+## Final Review Questions
+
+Before reporting a change as complete, answer these:
+
+- Did I search for all important call sites?
+- Did I preserve behavior that should not change?
+- Did I cover the changed behavior and at least one meaningful regression risk?
+- Did I check fork-specific impact where relevant?
+- Did I update `.ai/` docs if this work revealed a reusable lesson?
+
+Record skipped validation and residual risk clearly in the final response.

--- a/.ai/CODE_REVIEW.md
+++ b/.ai/CODE_REVIEW.md
@@ -281,6 +281,7 @@ Group related state and behavior together. If two fields are always set together
 - [ ] Clear naming: Variable names are unambiguous
 - [ ] TODOs linked: All TODOs have GitHub issue links
 - [ ] Tests present: Non-trivial changes have tests
+- [ ] Tests meaningful: Tests protect behavior/invariants, not just construction or mocks
+- [ ] Docs updated: Reusable testing, review, or development lessons are captured in `.ai/`
 - [ ] Lock safety: Lock ordering is safe and documented
 - [ ] No blocking: Async code doesn't block runtime
-

--- a/.ai/CODE_REVIEW.md
+++ b/.ai/CODE_REVIEW.md
@@ -277,6 +277,8 @@ Group related state and behavior together. If two fields are always set together
 
 - [ ] No panics: No `.unwrap()`, `.expect()`, unchecked array indexing
 - [ ] Consensus safe: If touching consensus crate, all arithmetic is safe
+- [ ] Regression-safe: Existing behavior that should not change is covered or explicitly checked
+- [ ] Interface sound: New or changed interfaces avoid unclear booleans/options and invalid states
 - [ ] Errors logged: Not silently swallowed
 - [ ] Clear naming: Variable names are unambiguous
 - [ ] TODOs linked: All TODOs have GitHub issue links

--- a/.ai/DEVELOPMENT.md
+++ b/.ai/DEVELOPMENT.md
@@ -71,6 +71,9 @@ Lighthouse is a modular Ethereum consensus client with two main components:
 
 ## Code Quality Standards
 
+Before changing shared behavior, read `.ai/CHANGE_SAFETY.md`. Before adding or
+changing interfaces, read `.ai/INTERFACE_DESIGN.md`.
+
 ### Panic Avoidance (Critical)
 
 **Panics should be avoided at all costs.**

--- a/.ai/DEVELOPMENT.md
+++ b/.ai/DEVELOPMENT.md
@@ -164,12 +164,15 @@ Avoid using the rayon global thread pool - it causes CPU oversubscription when b
 
 ## Testing Patterns
 
+Read `.ai/TESTING.md` before writing or modifying tests. Quick reference:
+
 - **Unit tests**: Single component edge cases
 - **Integration tests**: Use [`BeaconChainHarness`](beacon_node/beacon_chain/src/test_utils.rs) for end-to-end workflows
 - **Sync components**: Use [`TestRig`](beacon_node/network/src/sync/tests/mod.rs) pattern with event-based testing
 - **Mocking**: `mockall` for unit tests, `mockito` for HTTP APIs
 - **Adapter pattern**: For testing `BeaconChain` dependent components, create adapter structs. See [`fetch_blobs/tests.rs`](beacon_node/beacon_chain/src/fetch_blobs/tests.rs)
 - **Local testnet**: See `scripts/local_testnet/README.md`
+- **Doc upkeep**: If test work reveals a reusable lesson, update `.ai/TESTING.md` in the same change
 
 ## Build Notes
 

--- a/.ai/DOC_UPKEEP.md
+++ b/.ai/DOC_UPKEEP.md
@@ -1,0 +1,55 @@
+# AI Documentation Upkeep
+
+Read this when implementation, testing, review, or PR work reveals a reusable
+lesson for future AI assistants.
+
+## Default Behavior
+
+Update the relevant `.ai/` guide automatically in the same change when the lesson
+affects future code, tests, reviews, or PRs.
+
+Ask first only when:
+
+- The lesson is subjective or uncertain.
+- The correction is one-off and may not generalize.
+- The doc change would broaden the scope of the task.
+- The lesson conflicts with existing guidance.
+
+## Where to Put Lessons
+
+- `.ai/TESTING.md`: test helpers, fixture choices, fork-specific commands,
+  weak generated-test patterns, and invariant coverage.
+- `.ai/CODE_REVIEW.md`: review heuristics, recurring maintainer feedback, and
+  issues that reviewers should prioritize or ignore.
+- `.ai/ISSUES.md`: issue/PR format, labels, phrasing, and examples.
+- `.ai/DEVELOPMENT.md`: architecture, implementation patterns, commands, and
+  subsystem-specific conventions that do not fit a more specific guide.
+- `CLAUDE.md`: only always-on rules and routing. Keep it short because it is
+  loaded for every task.
+
+## Lesson Format
+
+```markdown
+### Lesson: [Brief Title]
+
+**Context:** [What task were you doing?]
+**Issue:** [What went wrong or was corrected?]
+**Learning:** [What to do differently next time]
+```
+
+Use this format for review lessons and larger corrections. For small testing or
+development discoveries, a concise bullet in the relevant section is enough.
+
+## When Not to Update
+
+- Minor preference differences.
+- One-off edge cases unlikely to recur.
+- Guidance already covered by an existing `.ai/` file.
+- Information that belongs in production docs, comments, or tests instead of AI
+  guidance.
+
+## Context Window Discipline
+
+Keep `CLAUDE.md` compact. New detailed guidance should usually live in `.ai/`
+and be linked from the routing table, so agents load it only when the task needs
+it.

--- a/.ai/DOC_UPKEEP.md
+++ b/.ai/DOC_UPKEEP.md
@@ -27,6 +27,31 @@ Ask first only when:
 - `CLAUDE.md`: only always-on rules and routing. Keep it short because it is
   loaded for every task.
 
+## Prefer Automation for Mechanical Rules
+
+Do not solve every recurring problem with prose. If a rule is objective and
+cheap to check, prefer enforcing it with existing tooling or a small script.
+
+Good candidates for automation:
+
+- Disallowed functions, methods, or unsafe patterns. Prefer clippy config or a
+  focused CI check.
+- Required formatting, dependency sorting, generated files, or lockfile updates.
+- Markdown or documentation structure that can be checked mechanically.
+- Repeated `rg`-style stale-reference checks after removing a feature, flag, or
+  type.
+- Required command coverage for a touched subsystem when the mapping is stable.
+
+Keep these as docs instead:
+
+- Judgment calls about interface shape, abstraction, or ownership.
+- Test quality expectations that require understanding behavior.
+- Review heuristics and examples of subtle regressions.
+- Domain decisions whose correctness depends on protocol context.
+
+When adding automation, document the command in `.ai/DEVELOPMENT.md` or the
+relevant focused guide, and make sure the final response reports whether it ran.
+
 ## Lesson Format
 
 ```markdown

--- a/.ai/INTERFACE_DESIGN.md
+++ b/.ai/INTERFACE_DESIGN.md
@@ -1,0 +1,104 @@
+# Interface Design Guide
+
+Read this before adding or changing structs, enums, traits, function signatures,
+config fields, APIs, events, database-facing types, or cross-subsystem
+interfaces.
+
+The goal is to make correct usage easy and incorrect usage hard.
+
+## Do Not Copy Bad Precedent Blindly
+
+Prefer local patterns by default, but do not preserve a pattern just because it
+exists nearby.
+
+Pause and reassess when existing code uses:
+
+- Boolean parameters whose meaning is unclear at call sites
+- Multiple `Option` parameters where only some combinations are valid
+- Parallel arrays or loosely related parameters that must stay index-aligned
+- Stringly typed state with a closed set of values
+- Generic wrappers, traits, or `Arc<Mutex<_>>` without a clear ownership need
+- Runtime panics in non-startup paths
+- Broad mocks that do not protect behavior
+- Helpers shared across forks or subsystems with undocumented assumptions
+
+If following the existing pattern would make the interface easier to misuse,
+prefer a better local design and explain the reason.
+
+## Make Invalid States Hard to Represent
+
+Use named types to encode meaning:
+
+- Prefer enums over booleans when there are named modes or future variants.
+- Prefer a struct over several parameters that are always passed together.
+- Prefer typed IDs, roots, slots, epochs, and fork names over raw primitives
+  where the codebase already has domain types.
+- Prefer explicit error variants over strings when callers need to react.
+- Use `Option<T>` only when absence is a real valid state.
+
+Avoid APIs where callers can pass contradictory combinations and rely on the
+callee to sort them out.
+
+## Keep Boundaries Honest
+
+Interfaces should match real ownership and responsibility:
+
+- Consensus rules belong in consensus/state-transition code, not API or sync
+  convenience layers.
+- Storage interfaces should expose domain operations, not backend quirks.
+- HTTP APIs should not leak internal helper shapes unless they are the intended
+  response contract.
+- Validator-client interfaces should not depend on beacon-node internals unless
+  the existing architecture already requires it.
+
+If an interface crosses subsystem boundaries, identify which subsystem owns the
+contract and keep conversion code at the boundary.
+
+## Avoid Premature Abstraction
+
+Do not add a trait, generic parameter, wrapper type, or new module just because
+two call sites look similar.
+
+Add abstraction only when:
+
+- There are real call sites with the same contract.
+- Tests need a narrow seam around external behavior.
+- The abstraction names a domain concept, not just an implementation step.
+- It reduces invalid states or repeated logic in a meaningful way.
+
+Three clear lines at two call sites are often better than a vague shared helper.
+
+## Signature Checklist
+
+Before changing a signature, check:
+
+- Are parameter names and types clear at every call site?
+- Would an enum or options struct be clearer than positional booleans/options?
+- Does the return type distinguish success, absence, invalid input, and external
+  failure correctly?
+- Are errors typed enough for callers to make the right decision?
+- Is the interface stable for older forks or existing users?
+- Does the new shape require migration, config updates, docs, or CLI changes?
+
+Run `rg` for all call sites and inspect the non-obvious ones.
+
+## Compatibility and Migration
+
+For public APIs, config, CLI, stored data, and wire formats:
+
+- Prefer additive changes when compatibility matters.
+- Document breaking changes clearly.
+- Update migrations, config examples, CLI docs, or API tests in the same change
+  when the interface requires it.
+- Keep serde defaults and skipped fields deliberate.
+- Do not change response status codes or error shapes accidentally.
+
+## Review Questions
+
+Before finalizing interface work, answer:
+
+- What invalid usage does this interface prevent?
+- What important behavior is now explicit in the type system?
+- Which caller is the hardest to reason about, and does the design still fit it?
+- Did I choose a better pattern where local precedent was weak?
+- Did I update `.ai/` docs if this decision should guide future work?

--- a/.ai/TESTING.md
+++ b/.ai/TESTING.md
@@ -1,0 +1,149 @@
+# Lighthouse Testing Guide
+
+Read this before writing, modifying, or reviewing tests. Lighthouse tests should
+prove protocol behavior and user-visible invariants, not just exercise new code.
+
+## Start With the Behavior
+
+Before editing tests, identify the behavior being protected:
+
+- What invariant, error path, fork rule, or API contract can regress?
+- Which existing test helper already builds the required world?
+- What would fail if the implementation were accidentally reverted?
+- Does the behavior differ by fork, network, store backend, or sync state?
+
+If the answer is unclear, inspect nearby tests before adding a new pattern.
+
+## Choose the Smallest Useful Test Layer
+
+- **Unit tests**: Pure functions, small state machines, serialization helpers,
+  error mapping, and edge cases that do not need a `BeaconChain`.
+- **Beacon chain tests**: Use `BeaconChainHarness` for block import, fork choice,
+  canonical head, state transition, execution payload, validator, or store
+  behavior that depends on chain context.
+- **Network/sync tests**: Use the existing `TestRig` pattern for event-driven
+  sync behavior. Prefer asserting emitted events and peer actions over internal
+  bookkeeping.
+- **HTTP API tests**: Use existing HTTP test utilities and mock external HTTP
+  calls with the repository's established mocking pattern.
+- **EF/spec tests**: Use Ethereum Foundation vectors when validating consensus
+  spec behavior or fork-specific state transition rules.
+
+Do not write a broad integration test when a focused unit test proves the same
+contract. Do not write a narrow unit test when the bug depends on chain state,
+fork choice, persistence, or async scheduling.
+
+## Use Existing Fixtures and Helpers
+
+Prefer the repository's test builders over hand-rolled fixtures:
+
+- `BeaconChainHarness` from `beacon_node/beacon_chain/src/test_utils.rs`
+- Fork-specific `FORK_NAME` tests where the crate supports `fork_from_env`
+- Existing store, sync, and HTTP API test utilities near the code under test
+- Adapter structs for `BeaconChain`-dependent components, following nearby
+  patterns such as `fetch_blobs/tests.rs`
+
+Generated tests often become weak when they create custom miniature worlds. If a
+helper exists, use it. If a helper is missing and multiple tests need it, add a
+small reusable helper next to the relevant tests.
+
+## Assert Invariants, Not Implementation Details
+
+Good Lighthouse tests usually assert one or more of:
+
+- Accepted vs rejected block, attestation, blob, data column, or payload
+- Canonical head, finalized checkpoint, justified checkpoint, or fork choice
+  outcome
+- Store persistence and reload behavior
+- Exact error variant for a consensus, validation, or API failure
+- Peer action, sync event, or request/response contract
+- Fork-specific behavior remaining unchanged for other forks
+
+Avoid tests that only assert a mock was called, a wrapper was constructed, or a
+private helper returned the same value it was given. Those tests usually survive
+broken behavior.
+
+## Cover Failure Paths
+
+For non-trivial changes, include at least one negative or boundary case when it
+is meaningful:
+
+- Missing data: no blobs, no data columns, absent payload, unknown parent
+- Invalid data: wrong root, wrong slot, wrong fork digest, bad signature
+- Boundary values: genesis, finalized boundary, first slot of a fork, empty
+  validator set, maximum committee or blob counts
+- Retry/fallback behavior: external failure, unavailable peer, missing store row
+
+Consensus and fork-choice changes need especially careful failure-path coverage.
+
+## Fork-Specific Changes
+
+When behavior changes for one fork:
+
+- Test the fork where behavior changes.
+- Verify earlier production forks still use the previous behavior when relevant.
+- Use `FORK_NAME=<fork> cargo nextest run ...` when the crate supports it.
+- Keep SSZ field ordering and default values in mind when touching types.
+
+Do not assume a test on the latest fork proves older forks are unaffected.
+
+## Async and Concurrency Tests
+
+- Prefer event-based assertions over sleeps.
+- If a timeout is necessary, keep it short and explain what progress signal is
+  expected.
+- Avoid blocking the async runtime. Use the repository's executor or blocking
+  helpers when a test needs CPU-heavy work.
+- When locks are involved, test the observable behavior and document any lock
+  ordering requirement in the production code.
+
+## Test Naming and Documentation
+
+- Use descriptive test names that state the condition and expected outcome.
+- Add a short comment only when the scenario is not obvious from the setup.
+- Do not reference PRs or issues as the only explanation. Describe the invariant
+  directly so the test remains useful outside GitHub context.
+- Keep setup compact. If setup hides the assertion, extract a helper.
+
+## Validation Commands
+
+During iteration, prefer the narrowest command that proves the change:
+
+```bash
+cargo nextest run -p <package> <test_name>
+cargo nextest run -p <package>
+FORK_NAME=electra cargo nextest run -p beacon_chain <test_name>
+```
+
+Before considering code changes complete, run the required project check from
+`CLAUDE.md`:
+
+```bash
+cargo check
+```
+
+For larger or cross-crate changes, also run the relevant broader command:
+
+```bash
+make test-release
+make lint
+make test-ef
+```
+
+Record any skipped validation and the reason in the final response.
+
+## Keep These Docs Current
+
+AI assistants should update the `.ai/` docs automatically when implementation or
+review work reveals a reusable lesson.
+
+Update `.ai/TESTING.md` in the same change when:
+
+- A maintainer corrects a generated test pattern.
+- You discover the right helper, fixture, or command for a test category.
+- A generated test passed but failed to protect the intended behavior.
+- A recurring edge case or fork-specific testing rule is not documented.
+
+Ask before updating only when the lesson is subjective, uncertain, or outside
+the scope of the current task. Otherwise, treat the doc update like a test fix:
+small, specific, and committed with the change that taught the lesson.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,10 +4,10 @@ This file provides guidance for AI assistants (Claude Code, Codex, etc.) working
 
 ## CRITICAL - Always Follow
 
-After completing ANY code changes:
-1. **MUST** run `cargo check` to verify compilation before considering task complete
-
-Run `make install-hooks` if you have not already to install git hooks. Never skip git hooks. If cargo is not available install the toolchain.
+- After completing ANY code changes, **MUST** run `cargo check` before considering the task complete.
+- Run `make install-hooks` if you have not already. Never skip git hooks. If cargo is not available, install the toolchain.
+- Branch from `unstable` and target `unstable` for PRs.
+- Update the relevant `.ai/` guide in the same change when work reveals a reusable lesson.
 
 ## Quick Reference
 
@@ -35,70 +35,23 @@ Read the relevant guide for your task:
 | **Code review** | `.ai/CODE_REVIEW.md` |
 | **Creating issues/PRs** | `.ai/ISSUES.md` |
 | **Development patterns** | `.ai/DEVELOPMENT.md` |
+| **Writing or modifying tests** | `.ai/TESTING.md` |
+| **Updating AI docs** | `.ai/DOC_UPKEEP.md` |
 
-## Critical Rules (consensus failures or crashes)
+Read only the guides relevant to the task. Do not load every `.ai/` file by default.
 
-### 1. No Panics at Runtime
+## Always-On Rules
 
-```rust
-// NEVER
-let value = option.unwrap();
-let item = array[1];
+- No runtime panics: avoid `.unwrap()`, `.expect()`, and unchecked indexing outside startup/config validation.
+- In `consensus/` excluding `types/`, use saturating or checked arithmetic.
+- Never block the async runtime. Use the repository's blocking helpers for CPU-heavy work.
+- Document lock ordering when touching code that takes multiple locks.
+- Use scoped rayon pools from beacon processor, not the global rayon pool.
+- All `TODO` comments must link to a GitHub issue.
+- Avoid ambiguous abbreviations. Use names like `beacon_block` and `blob`.
 
-// ALWAYS
-let value = option?;
-let item = array.get(1)?;
-```
+## Extra PR Guidelines
 
-Only acceptable during startup for CLI/config validation.
-
-### 2. Consensus Crate: Safe Math Only
-
-In `consensus/` (excluding `types/`), use saturating or checked arithmetic:
-
-```rust
-// NEVER
-let result = a + b;
-
-// ALWAYS
-let result = a.saturating_add(b);
-```
-
-## Important Rules (bugs or performance issues)
-
-### 3. Never Block Async
-
-```rust
-// NEVER
-async fn handler() { expensive_computation(); }
-
-// ALWAYS
-async fn handler() {
-    tokio::task::spawn_blocking(|| expensive_computation()).await?;
-}
-```
-
-### 4. Lock Ordering
-
-Document lock ordering to avoid deadlocks. See [`canonical_head.rs:9-32`](beacon_node/beacon_chain/src/canonical_head.rs) for the pattern.
-
-### 5. Rayon Thread Pools
-
-Use scoped rayon pools from beacon processor, not global pool. Global pool causes CPU oversubscription when beacon processor has allocated all CPUs.
-
-## Good Practices
-
-### 6. TODOs Need Issues
-
-All `TODO` comments must link to a GitHub issue.
-
-### 7. Clear Variable Names
-
-Avoid ambiguous abbreviations (`bb`, `bl`). Use `beacon_block`, `blob`.
-
-## Branch & PR Guidelines
-
-- Branch from `unstable`, target `unstable` for PRs
 - Run `cargo sort` when adding dependencies
 - Run `make cli-local` when updating CLI flags
 
@@ -117,42 +70,3 @@ consensus/
 ```
 
 See `.ai/DEVELOPMENT.md` for detailed architecture.
-
-## Maintaining These Docs
-
-**These AI docs should evolve based on real interactions.**
-
-### After Code Reviews
-
-If a developer corrects your review feedback or points out something you missed:
-- Ask: "Should I update `.ai/CODE_REVIEW.md` with this lesson?"
-- Add to the "Common Review Patterns" or create a new "Lessons Learned" entry
-- Include: what went wrong, what the feedback was, what to do differently
-
-### After PR/Issue Creation
-
-If a developer refines your PR description or issue format:
-- Ask: "Should I update `.ai/ISSUES.md` to capture this?"
-- Document the preferred style or format
-
-### After Development Work
-
-If you learn something about the codebase architecture or patterns:
-- Ask: "Should I update `.ai/DEVELOPMENT.md` with this?"
-- Add to relevant section or create new patterns
-
-### Format for Lessons
-
-```markdown
-### Lesson: [Brief Title]
-
-**Context:** [What task were you doing?]
-**Issue:** [What went wrong or was corrected?]
-**Learning:** [What to do differently next time]
-```
-
-### When NOT to Update
-
-- Minor preference differences (not worth documenting)
-- One-off edge cases unlikely to recur
-- Already covered by existing documentation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,9 @@ Read the relevant guide for your task:
 |------|-----------------|
 | **Code review** | `.ai/CODE_REVIEW.md` |
 | **Creating issues/PRs** | `.ai/ISSUES.md` |
+| **Changing behavior or shared code paths** | `.ai/CHANGE_SAFETY.md` |
 | **Development patterns** | `.ai/DEVELOPMENT.md` |
+| **Designing interfaces or APIs** | `.ai/INTERFACE_DESIGN.md` |
 | **Writing or modifying tests** | `.ai/TESTING.md` |
 | **Updating AI docs** | `.ai/DOC_UPKEEP.md` |
 


### PR DESCRIPTION
## Issue Addressed

No issue.

## Proposed Changes

- Slim `CLAUDE.md` into an always-loaded routing guide to reduce context usage.
- Add `.ai/DOC_UPKEEP.md` so AI assistants update reusable guidance automatically without loading the detailed policy for every task.
- Add `.ai/TESTING.md` with guidance for meaningful Lighthouse tests, fixture selection, fork-specific coverage, and validation commands.
- Add `.ai/CHANGE_SAFETY.md` to make agents trace call sites, preserve existing behavior deliberately, and cover regression risks.
- Add `.ai/INTERFACE_DESIGN.md` to discourage copying weak precedent and guide better API/type/interface choices.
- Link the focused guides from development and code review guidance.
- Document when mechanical rules should be enforced with scripts or existing tooling instead of more prose.

## Additional Info

Docs-only change. Validated with `git diff --check`.